### PR TITLE
fixed a typo

### DIFF
--- a/htb-recon.sh
+++ b/htb-recon.sh
@@ -46,7 +46,7 @@ then
   tmux send-keys -t htb_recon:NOTES 'vi Notes.md'
 
 else
-  echo "Usage: ./htb-recon.sh <IP> <Name_of_Machin> <OS> "
+  echo "Usage: ./htb-recon.sh <IP> <Name_of_Machine> <OS> "
   echo "Example: ./workspace.sh 10.10.10.180 ServMon Windows"
 
 fi


### PR DESCRIPTION
I fixed a typo in the line 49:
'machin' => 'machine'